### PR TITLE
Uniformly collapse blank lines within a category

### DIFF
--- a/usort/cli.py
+++ b/usort/cli.py
@@ -13,7 +13,6 @@ import click
 from moreorless.click import echo_color_unified_diff
 
 from usort.translate import render_node
-
 from . import __version__
 from .api import usort_path, usort_stdin
 from .config import Config

--- a/usort/sorting.py
+++ b/usort/sorting.py
@@ -238,7 +238,7 @@ class ImportSorter:
             elif imp.sort_key.category_index != cur_category:
                 blanks = ("",)
             else:
-                blanks = _old_blanks[:1]
+                blanks = ()
 
             imp.comments.before = [*blanks, *old_comments]
 

--- a/usort/tests/functional.py
+++ b/usort/tests/functional.py
@@ -365,11 +365,10 @@ numpy = ["numpy", "pandas"]
         """
         self.assertUsortResult(content, content, config)
 
-    def test_match_black_blank_line_before_comment(self) -> None:
+    def test_collapse_blank_line_before_comment(self) -> None:
         content = """
             import a
             import b
-
             # comment
             import c
         """
@@ -805,7 +804,6 @@ numpy = ["numpy", "pandas"]
             """,
             """
                 import a
-
                 # one
                 # apple
                 from foo import (  # two  # banana
@@ -1026,6 +1024,75 @@ excludes = [
                 self.assertEqual(sorted_content, result.output.replace(b"\r\n", b"\n"))
             self.assertEqual(len(sorted_paths), len(results))
 
+    def test_sorting_with_extra_blank_lines(self) -> None:
+        self.assertUsortResult(
+            """
+                import math
+
+                import beta
+                from . import foo
+                import alpha
+            """,
+            """
+                import math
+
+                import alpha
+                import beta
+
+                from . import foo
+            """,
+        )
+
+        self.assertUsortResult(
+            """
+                import math
+
+
+                import beta
+                from . import foo
+
+                import alpha
+            """,
+            """
+                import math
+
+                import alpha
+                import beta
+
+                from . import foo
+            """,
+        )
+
+        self.assertUsortResult(
+            """
+                import math
+
+                import gamma
+
+                import alpha
+
+
+                # special
+                import beta
+
+                from . import foo
+
+                import zeta
+
+            """,
+            """
+                import math
+
+                import alpha
+                # special
+                import beta
+                import gamma
+                import zeta
+
+                from . import foo
+
+            """,
+        )
 
 if __name__ == "__main__":
     unittest.main()

--- a/usort/tests/functional.py
+++ b/usort/tests/functional.py
@@ -1094,5 +1094,6 @@ excludes = [
             """,
         )
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/usort/tests/sorting.py
+++ b/usort/tests/sorting.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import libcst as cst
 
 from ..config import Config
-
 from ..sorting import ImportSorter
 
 


### PR DESCRIPTION
The simplest possible method of handling #163:

Removes all blank lines between imports within a single category. No exceptions.