### PR TITLE
Detect/enable the native LibCST parser by default

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -19,3 +19,7 @@ Advanced API
 .. autofunction:: usort_file
 .. autofunction:: usort_stdin
 .. autoclass:: Config
+
+.. module:: usort.util
+
+.. autofunction:: enable_libcst_native

--- a/usort/cli.py
+++ b/usort/cli.py
@@ -18,7 +18,7 @@ from .api import usort_path, usort_stdin
 from .config import Config
 from .sorting import ImportSorter
 from .types import Options
-from .util import get_timings, print_timings, Timing, try_parse
+from .util import enable_libcst_native, get_timings, print_timings, Timing, try_parse
 
 BENCHMARK = False
 
@@ -56,6 +56,7 @@ def main(ctx: click.Context, benchmark: bool, debug: bool) -> None:
     logging.basicConfig(level=level, stream=sys.stderr)
 
     ctx.obj = Options(debug=debug)
+    enable_libcst_native()
 
 
 @main.command()

--- a/usort/cli.py
+++ b/usort/cli.py
@@ -48,7 +48,13 @@ def usort_command(fn: Callable[..., int]) -> Callable[..., None]:
 @click.version_option(__version__, "--version", "-V")
 @click.option("--debug", is_flag=True, help="Enable debug output")
 @click.option("--benchmark", is_flag=True, help="Output benchmark timing info")
-def main(ctx: click.Context, benchmark: bool, debug: bool) -> None:
+@click.option(
+    "--native / --no-native",
+    is_flag=True,
+    default=True,
+    help="Enable or disable the native parser",
+)
+def main(ctx: click.Context, benchmark: bool, debug: bool, native: bool) -> None:
     global BENCHMARK
     BENCHMARK = benchmark
 
@@ -56,7 +62,9 @@ def main(ctx: click.Context, benchmark: bool, debug: bool) -> None:
     logging.basicConfig(level=level, stream=sys.stderr)
 
     ctx.obj = Options(debug=debug)
-    enable_libcst_native()
+
+    if native:
+        enable_libcst_native()
 
 
 @main.command()

--- a/usort/tests/__main__.py
+++ b/usort/tests/__main__.py
@@ -7,4 +7,4 @@ import unittest
 
 from usort.tests import *  # noqa: F401,F403
 
-unittest.main()
+unittest.main(verbosity=2)

--- a/usort/tests/cli.py
+++ b/usort/tests/cli.py
@@ -229,7 +229,8 @@ import os
 
         self.assertRegex(
             result.output,
-            r"Error sorting sample\.py: Syntax Error @ 1:7\.",
+            r"Error sorting sample\.py: Syntax Error @ 1:1\.\n"
+            r"parser error: error at 2:0: expected NAME",
         )
         self.assertEqual(result.exit_code, 1)
 
@@ -242,7 +243,8 @@ import os
 
         self.assertRegex(
             result.output,
-            r"Error sorting sample\.py: Syntax Error @ 2:11\.",
+            r"Error sorting sample\.py: Syntax Error @ 2:1\.\n"
+            r"parser error: error at 2:13: expected one of ",
         )
         self.assertEqual(result.exit_code, 1)
 

--- a/usort/util.py
+++ b/usort/util.py
@@ -55,7 +55,12 @@ def print_timings(
 
 def enable_libcst_native() -> bool:
     """
-    Attempt to enable LibCST's native parser if available.
+    Attempt to enable LibCST's faster, native PEG parser if available.
+
+    This enables parsing files with 3.10 match statements, or other new syntax features
+    dependent on having a PEG style parser. This is currently not the default parser
+    in LibCST, so this function must be called before parsing files with 3.10+ syntax,
+    or otherwise set the environment variable ``LIBCST_PARSER_TYPE="native"``.
 
     Returns ``True`` if the native parser was found and enabled, or ``False`` otherwise.
     """

--- a/usort/util.py
+++ b/usort/util.py
@@ -3,6 +3,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+
+import importlib
+import logging
+import os
 import re
 from contextlib import contextmanager
 from pathlib import Path
@@ -13,6 +17,8 @@ import libcst as cst
 
 Timing = Tuple[str, float]
 
+LOG = logging.getLogger(__name__)
+LIBCST_PARSER_TYPE = "LIBCST_PARSER_TYPE"
 INLINE_COMMENT_RE = re.compile(r"#+[^#]*")
 TIMINGS: List[Timing] = []
 
@@ -45,6 +51,29 @@ def print_timings(
     """
     for msg, duration in timings:
         fn(f"{msg + ':':50} {int(duration*1000000):7} µs")
+
+
+def enable_libcst_native() -> bool:
+    """
+    Attempt to enable LibCST's native parser if available.
+
+    Returns ``True`` if the native parser was found and enabled, or ``False`` otherwise.
+    """
+
+    try:
+        LOG.debug("checking for libcst native parser")
+        # use importlib so that we can test/mock import errors
+        module = importlib.import_module("libcst.native")
+
+        if hasattr(module, "parse_module"):
+            os.environ[LIBCST_PARSER_TYPE] = "native"
+            LOG.debug("libcst native parser enabled")
+            return True
+
+    except ImportError:
+        LOG.debug("libcst native module not available")
+
+    return False
 
 
 def try_parse(path: Path, data: Optional[bytes] = None) -> cst.Module:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #244

Adds a helper function to detect the presence of the `libcst.native`
parser module, and enable its use in LibCST appropriately. If the native
module is not available, or it does not contain the `parse_module`
function that we expect to use, then the native parser is not enabled.

Adds support for parsing 3.10 match statements, as well as future syntax
that requires use of the PEG parsing features only available in LibCST's
native parser.

This is currently only enabled in the µsort CLI entrypoint. Programs
using the µsort API directly will need to call or enable the native
parser separately if desired.

Fixes #216