### PR TITLE
Correctly track inline comments on items without trailing commas

### DIFF
--- a/usort/tests/functional.py
+++ b/usort/tests/functional.py
@@ -408,29 +408,31 @@ numpy = ["numpy", "pandas"]
     def test_multi_line_maintain(self) -> None:
         self.assertUsortResult(
             """
-                from fuzz import buzz
+                from phi import rho
                 # one
-                from foo import (  # two
+                from alpha import (  # two
                     # three
-                    bar,  # four
+                    beta,  # four
                     # five
-                    baz # six
+                    delta # six
                     , # seven
-                    # eight
-                )  # nine
-                # ten
+                    gamma # eight
+                    # nine
+                )  # ten
+                # eleven
             """,
             """
                 # one
-                from foo import (  # two
+                from alpha import (  # two
                     # three
-                    bar,  # four
+                    beta,  # four
                     # five
-                    baz,  # six  # seven
-                    # eight
-                )  # nine
-                from fuzz import buzz
-                # ten
+                    delta,  # six  # seven
+                    gamma,  # eight
+                    # nine
+                )  # ten
+                from phi import rho
+                # eleven
             """,
         )
 
@@ -438,30 +440,32 @@ numpy = ["numpy", "pandas"]
         self.assertUsortResult(
             """
                 def foo():
-                    from fuzz import buzz
+                    from phi import rho
                     # one
-                    from foo import (  # two
+                    from alpha import (  # two
                         # three
-                        bar,  # four
+                        beta,  # four
                         # five
-                        baz # six
+                        delta # six
                         , # seven
-                        # eight
-                    )  # nine
-                    # ten
+                        gamma # eight
+                        # nine
+                    )  # ten
+                    # eleven
             """,
             """
                 def foo():
                     # one
-                    from foo import (  # two
+                    from alpha import (  # two
                         # three
-                        bar,  # four
+                        beta,  # four
                         # five
-                        baz,  # six  # seven
-                        # eight
-                    )  # nine
-                    from fuzz import buzz
-                    # ten
+                        delta,  # six  # seven
+                        gamma,  # eight
+                        # nine
+                    )  # ten
+                    from phi import rho
+                    # eleven
             """,
         )
 
@@ -470,20 +474,22 @@ numpy = ["numpy", "pandas"]
             """
                 from fuzz import buzz
                 # 1
-                from foo import (  # 2
+                from a import (  # 2
                     # 3
-                    bar,  # 4
+                    b,  # 4
                     # 5
-                    baz # 6
+                    c # 6
                     , # 7
-                )  # 8
-                # 9
+                    d # 8
+                    # 9
+                )  # 10
+                # 11
             """,
             """
                 # 1
-                from foo import bar, baz  # 2  # 3  # 4  # 5  # 6  # 7  # 8
+                from a import b, c, d  # 2  # 3  # 4  # 5  # 6  # 7  # 8  # 9  # 10
                 from fuzz import buzz
-                # 9
+                # 11
             """,
         )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #252
* __->__ #251
* #250

Fixes #249