### PR TITLE
Option for obeying magic trailing commas

### DIFF
--- a/usort/config.py
+++ b/usort/config.py
@@ -55,6 +55,9 @@ class Config:
     # Whether to perform the first-party heuristic during find()
     first_party_detection: bool = True
 
+    # Whether to follow black-style for magic trailing commas
+    magic_commas: bool = False
+
     # Whether to merge imports when sorting
     merge_imports: bool = True
 
@@ -156,8 +159,10 @@ class Config:
             self.side_effect_modules.extend(tbl["side_effect_modules"])
         if "first_party_detection" in tbl:
             self.first_party_detection = tbl["first_party_detection"]
+        if "magic_commas" in tbl:
+            self.magic_commas = bool(tbl["magic_commas"])
         if "merge_imports" in tbl:
-            self.merge_imports = tbl["merge_imports"]
+            self.merge_imports = bool(tbl["merge_imports"])
         if "excludes" in tbl:
             self.excludes = tbl["excludes"]
 

--- a/usort/tests/config.py
+++ b/usort/tests/config.py
@@ -171,6 +171,48 @@ foo = ["numpy", "pandas"]
             # from foo.bar import bazzy
             self.assertFalse(config.is_side_effect_import("foo.bar", ["bazzy"]))
 
+    def test_config_magic_commas(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            d_path = Path(d)
+            (d_path / "foo").mkdir(parents=True)
+            (d_path / "foo" / "bar.py").write_text("import os")
+
+            with self.subTest("default"):
+                (d_path / "foo" / "pyproject.toml").write_text("")
+                conf = Config.find(d_path / "foo" / "bar.py")
+                self.assertFalse(conf.magic_commas)
+
+            with self.subTest("enabled"):
+                (d_path / "foo" / "pyproject.toml").write_text(
+                    """\
+[tool.usort]
+magic_commas = true
+"""
+                )
+                conf = Config.find(d_path / "foo" / "bar.py")
+                self.assertTrue(conf.magic_commas)
+
+    def test_config_merge_imports(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            d_path = Path(d)
+            (d_path / "foo").mkdir(parents=True)
+            (d_path / "foo" / "bar.py").write_text("import os")
+
+            with self.subTest("default"):
+                (d_path / "foo" / "pyproject.toml").write_text("")
+                conf = Config.find(d_path / "foo" / "bar.py")
+                self.assertTrue(conf.merge_imports)
+
+            with self.subTest("disabled"):
+                (d_path / "foo" / "pyproject.toml").write_text(
+                    """\
+[tool.usort]
+merge_imports = false
+"""
+                )
+                conf = Config.find(d_path / "foo" / "bar.py")
+                self.assertFalse(conf.merge_imports)
+
     def test_config_excludes(self) -> None:
         with tempfile.TemporaryDirectory() as d:
             d_path = Path(d)

--- a/usort/tests/functional.py
+++ b/usort/tests/functional.py
@@ -736,6 +736,46 @@ numpy = ["numpy", "pandas"]
             """,
         )
 
+    def test_magic_commas_disabled(self) -> None:
+        self.assertUsortResult(
+            """
+                from a import (
+                    b,
+                    c,
+                )
+                from foo import ( # important comment
+                    bar,
+                    baz  # @manual
+                )
+            """,
+            """
+                from a import b, c
+                from foo import bar, baz  # important comment  # @manual
+            """,
+        )
+
+    def test_magic_commas_enabled(self) -> None:
+        self.assertUsortResult(
+            """
+                from a import (
+                    b,
+                    c,
+                )
+                from foo import (  # important comment
+                    bar,
+                    baz  # @manual
+                )
+            """,
+            """
+                from a import (
+                    b,
+                    c,
+                )
+                from foo import bar, baz  # important comment  # @manual
+            """,
+            Config(magic_commas=True),
+        )
+
     def test_merging_import_items(self) -> None:
         self.assertUsortResult(
             """

--- a/usort/tests/translate.py
+++ b/usort/tests/translate.py
@@ -11,6 +11,7 @@ import libcst as cst
 from ..config import Config
 from ..sorting import ImportSorter
 from ..translate import import_from_node
+from ..types import SortableImport, SortableImportItem
 from ..util import parse_import
 
 
@@ -80,6 +81,27 @@ class SortableImportTest(unittest.TestCase):
         self.assertEqual("a", imp.items[0].name)
         self.assertEqual("b", imp.items[0].asname)
         self.assertEqual({"b": ".a"}, imp.imported_names)
+
+    def test_import_from_node_multiline(self) -> None:
+        imp = import_from_node(parse_import("from a import (\n  b,\n  c\n)"), Config())
+        expected = SortableImport(
+            stem="a",
+            items=[
+                SortableImportItem(name="b", asname="", stem="a", comma=True),
+                SortableImportItem(name="c", asname="", stem="a", comma=False),
+            ],
+        )
+        self.assertListEqual(expected.items, imp.items)
+
+        imp = import_from_node(parse_import("from a import (\n  b,\n  c,\n)"), Config())
+        expected = SortableImport(
+            stem="a",
+            items=[
+                SortableImportItem(name="b", asname="", stem="a", comma=True),
+                SortableImportItem(name="c", asname="", stem="a", comma=True),
+            ],
+        )
+        self.assertListEqual(expected.items, imp.items)
 
 
 class IsSortableTest(unittest.TestCase):

--- a/usort/tests/types.py
+++ b/usort/tests/types.py
@@ -214,6 +214,27 @@ class TypesTest(unittest.TestCase):
             ):
                 a += 10  # type: ignore
 
+    def test_sortable_import_trailing_comma(self) -> None:
+        imp = types.SortableImport(
+            stem="a",
+            items=[
+                types.SortableImportItem(name="b", asname="", stem="a", comma=True),
+                types.SortableImportItem(name="c", asname="", stem="a", comma=True),
+                types.SortableImportItem(name="d", asname="", stem="a", comma=False),
+            ],
+        )
+        self.assertFalse(imp.trailing_comma)
+
+        imp = types.SortableImport(
+            stem="a",
+            items=[
+                types.SortableImportItem(name="b", asname="", stem="a", comma=True),
+                types.SortableImportItem(name="c", asname="", stem="a", comma=True),
+                types.SortableImportItem(name="d", asname="", stem="a", comma=True),
+            ],
+        )
+        self.assertTrue(imp.trailing_comma)
+
     def test_sortable_block_repr(self) -> None:
         imp = types.SortableBlock(
             start_idx=0,

--- a/usort/types.py
+++ b/usort/types.py
@@ -106,8 +106,11 @@ class SortKey:
 class SortableImportItem:
     name: str = field(order=str.casefold)
     asname: Optional[str] = field(eq=True, order=case_insensitive_ordering)
-    comments: ImportItemComments = field(eq=False, order=False)
+    comments: ImportItemComments = field(
+        eq=False, order=False, factory=ImportItemComments
+    )
     stem: Optional[str] = field(order=False, default=None, repr=False)
+    comma: bool = field(eq=False, order=False, default=False, repr=False)
 
     @property
     def fullname(self) -> str:
@@ -133,8 +136,8 @@ class SortableImport:
     sort_key: SortKey = field(init=False)
     stem: Optional[str] = field(order=case_insensitive_ordering)  # "from" imports
     items: List[SortableImportItem] = field()
-    comments: ImportComments = field(order=False)
-    indent: str = field(order=False)
+    comments: ImportComments = field(order=False, factory=ImportComments)
+    indent: str = field(order=False, default="")
     config: Config = field(eq=False, order=False, factory=Config)
 
     # for cli/debugging only
@@ -202,6 +205,12 @@ class SortableImport:
             config=self.config,
             node=self.node,
         )
+
+    @property
+    def trailing_comma(self) -> bool:
+        if self.items:
+            return self.items[-1].comma
+        return False
 
     @property
     def imported_names(self) -> Dict[str, str]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Adds a new configuration option to prevent collapsing multi-line import
statements with trailing commas, similar to black's behavior.

This is disabled by default, maintaining exist behavior of collapsing
multi-line imports whenever they can fit on a single line.

Fixes #247