### PR TITLE
remove py27 only modules from known stdlib

### DIFF
--- a/usort/stdlibs.py
+++ b/usort/stdlibs.py
@@ -5,6 +5,6 @@
 
 from typing import FrozenSet
 
-from stdlibs import py27, py3
+from stdlibs import py3
 
-STDLIB_TOP_LEVEL_NAMES: FrozenSet[str] = py27.module_names | py3.module_names
+STDLIB_TOP_LEVEL_NAMES: FrozenSet[str] = py3.module_names

--- a/usort/tests/stdlibs.py
+++ b/usort/tests/stdlibs.py
@@ -11,7 +11,7 @@ from usort.stdlibs import STDLIB_TOP_LEVEL_NAMES
 class StdlibsTest(unittest.TestCase):
     def test_expected(self) -> None:
         # Py2 module
-        self.assertIn("StringIO", STDLIB_TOP_LEVEL_NAMES)
+        self.assertNotIn("StringIO", STDLIB_TOP_LEVEL_NAMES)
 
         # This is specialcased, it appears to be a packaging decision for distros but I
         # don't want to include it.
@@ -23,6 +23,6 @@ class StdlibsTest(unittest.TestCase):
         self.assertIn("os", STDLIB_TOP_LEVEL_NAMES)
 
         # Py2 module
-        self.assertIn("sre", STDLIB_TOP_LEVEL_NAMES)
+        self.assertNotIn("sre", STDLIB_TOP_LEVEL_NAMES)
         for name in ("re", "sre_parse", "_sre"):
             self.assertIn(name, STDLIB_TOP_LEVEL_NAMES)

--- a/usort/tests/stdlibs.py
+++ b/usort/tests/stdlibs.py
@@ -12,6 +12,8 @@ class StdlibsTest(unittest.TestCase):
     def test_expected(self) -> None:
         # Py2 module
         self.assertNotIn("StringIO", STDLIB_TOP_LEVEL_NAMES)
+        # See https://github.com/omnilib/stdlibs/issues/57
+        self.assertNotIn("panel", STDLIB_TOP_LEVEL_NAMES)
 
         # This is specialcased, it appears to be a packaging decision for distros but I
         # don't want to include it.


### PR DESCRIPTION
Addresses https://github.com/omnilib/stdlibs/issues/57#issuecomment-1643112650.