### PR TITLE
Convert toml dependency to tomllib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "LibCST >= 0.3.7",
     "moreorless >= 0.3.0",
     "stdlibs >= 2021.4.1",
-    "toml >= 0.10.0",
+    "tomli;python_version<'3.11'",
     "trailrunner >= 1.0, < 2.0",
 ]
 dynamic = ["version"]

--- a/usort/config.py
+++ b/usort/config.py
@@ -4,11 +4,15 @@
 # LICENSE file in the root directory of this source tree.
 
 import re
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, NewType, Optional, Pattern, Sequence, Set
 
-import toml
+if sys.version_info < (3, 11):
+    import tomli as tomllib
+else:
+    import tomllib
 
 from .stdlibs import STDLIB_TOP_LEVEL_NAMES
 
@@ -147,7 +151,7 @@ class Config:
         return self
 
     def update_from_config(self, toml_path: Path) -> None:
-        conf = toml.loads(toml_path.read_text())
+        conf = tomllib.loads(toml_path.read_text())
         tool = conf.get("tool", {})
         tbl = tool.get("usort", {})
 


### PR DESCRIPTION
`toml` dependency is deprecated in Fedora downstream and it is scheduled to be retired soon